### PR TITLE
feat: add postcss to default style language enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,7 +453,8 @@
                             "scss",
                             "sass",
                             "less",
-                            "stylus"
+                            "stylus",
+                            "postcss"
                         ],
                         "description": "Default language for style tag"
                     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

Resolves https://github.com/nuxtrdev/nuxtr-vscode/discussions/25

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds postcss to the list of supported languages. I'm new to the codebase, does it needs to be added elsewhere ?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
