### PR TITLE
fix: remove plugins watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### Version 0.1.11
+
+🩹 Fixes
+
+- Removing Plugins watcher.
+
 ### Version 0.1.9
 
 📦 New

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nuxtr-vscode",
     "displayName": "Nuxtr",
     "description": "An extension for Nuxt.js offering commands and tools to make your experience more pleasant.",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "packageManager": "pnpm@8.6.8",
     "engines": {
         "vscode": "^1.80.0"

--- a/src/watchers/index.ts
+++ b/src/watchers/index.ts
@@ -66,31 +66,6 @@ class FileWatchers {
             this.sidebarProvider.getDependencies()
         })
 
-
-    public pluginsFileWatcher = workspace
-        .createFileSystemWatcher(`${projectRootDirectory()}/plugins/**/*`)
-        .onDidCreate(async (uri: Uri) => {
-            const pluginsFiles = await workspace.findFiles('plugins/**/*').then((files) => {
-                return files.map((file: any) => {
-                    return file.path.replace(`${projectRootDirectory()}/`, '~/')
-                })
-            })
-            updateNuxtConfig((config) => config.plugins = pluginsFiles)
-        })
-
-    public pluginsFileWatcherDeleted = workspace
-        .createFileSystemWatcher(`${projectRootDirectory()}/plugins/**/*`)
-        .onDidDelete(async (uri: Uri) => {
-
-            const pluginsFiles = await workspace.findFiles('plugins/**/*').then((files) => {
-                return files.map((file: any) => {
-                    return file.path.replace(`${projectRootDirectory()}/`, '~/')
-                })
-            })
-
-            updateNuxtConfig((config) => config.plugins = pluginsFiles)
-        })
-
 }
 
 export default FileWatchers


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/22491

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxtr watching plugins is against the recommendations of [Nuxt Docs](https://nuxt.com/docs/guide/directory-structure/plugins#plugins-directory). This PR is to remove it. 

