### PR TITLE
fix: rename vueBaseFile to vueBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ While using the CLI directly from your terminal is perfectly viable, Nuxtr's int
 
 **Nuxt Snippets**: Enhance your development speed with Nuxt snippets. Simply type `nuxt` for components, `use` for Composables, or begin typing Nuxt utilities and select your desired snippet from the list.
 
-Starting 0.2.10, you can inject a dynamic snippet based on your Nuxtr Vue files configuration with `vueBaseFile` or `vueBaseLayout`.
+Starting 0.2.10, you can inject a dynamic snippet based on your Nuxtr Vue files configuration with `vueBase` or `vueBaseLayout`.
 
 Nuxt Snippets are enabled by default. You can toggle them on or off using this setting:
 

--- a/src/snippets/index.ts
+++ b/src/snippets/index.ts
@@ -54,7 +54,7 @@ export const vuePageTemplate = languages.registerCompletionItemProvider(
     { language: 'vue' },
     {
         provideCompletionItems(document: TextDocument, position: Position) {
-            const completionItem = new CompletionItem('vueBaseFile', CompletionItemKind.Snippet);
+            const completionItem = new CompletionItem('vueBase', CompletionItemKind.Snippet);
             completionItem.detail = 'Generate a Vue page/component template';
 
             const template = generateVueFileBasicTemplate('page');


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Base snippet prefix conflicts with `v-if` filteration in case users are searching with `vi`. Renaming should avoid this incident. 
 
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
