### PR TITLE
fix: nuxt module installation

### DIFF
--- a/src/commands/CSS.ts
+++ b/src/commands/CSS.ts
@@ -58,8 +58,8 @@ const configureTailwind = () => {
                 if (selections !== undefined && selections.length > 0) {
                     if (selections.includes(TailwindOptions.installModule)) {
                         const moduleName = '@nuxtjs/tailwindcss'
-                        const tailwindCommand = await getInstallationCommand('tailwindcss', true)
-                        const moduleCommand = await getInstallationCommand(moduleName, true)
+                        const tailwindCommand = await getInstallationCommand('tailwindcss')
+                        const moduleCommand = await getInstallationCommand(moduleName)
 
                         if (!isNuxtTwo()) {
                             await runCommand({
@@ -127,7 +127,7 @@ const configureWindi = async () => {
                 if (selections !== undefined && selections.length > 0) {
                     if (selections.includes(WindiOptions.installModule)) {
                         const moduleName = 'nuxt-windicss'
-                        const command = await getInstallationCommand(moduleName, true)
+                        const command = await getInstallationCommand(moduleName)
 
                         await runCommand({
                             command,
@@ -175,7 +175,7 @@ const configureUno = async () => {
                 if (selections !== undefined && selections.length > 0) {
                     if (selections.includes(UnoCSSOptions.installModule)) {
                         const moduleName = '@unocss/nuxt'
-                        const command = await getInstallationCommand(moduleName, true)
+                        const command = await getInstallationCommand(moduleName)
 
                         await runCommand({
                             command,
@@ -223,7 +223,7 @@ const configureVuetify = async () => {
                 if (selections !== undefined && selections.length > 0) {
                     if (selections.includes(VuetifyOptions.installModule)) {
                         const moduleName = '@nuxtjs/vuetify'
-                        const command = await getInstallationCommand(moduleName, true)
+                        const command = await getInstallationCommand(moduleName)
 
                         await runCommand({
                             command,

--- a/src/commands/Devtools.ts
+++ b/src/commands/Devtools.ts
@@ -98,7 +98,7 @@ async function installDevtools() {
         "Close"
     );
     if (response === "Install") {
-        const command = await getInstallationCommand(moduleName, true);
+        const command = await getInstallationCommand(moduleName);
 
         await runCommand({
             command,

--- a/src/commands/Linters.ts
+++ b/src/commands/Linters.ts
@@ -46,7 +46,7 @@ const configureEslint = () => {
                 if (selections !== undefined && selections.length > 0) {
                     if (selections.includes(EslintOptions.installModule)) {
                         const moduleName = '@nuxtjs/eslint-config-typescript eslint'
-                        const command = await getInstallationCommand(moduleName, true)
+                        const command = await getInstallationCommand(moduleName)
 
                         await runCommand({
                             command,
@@ -101,7 +101,7 @@ const configureStylelint = () => {
                 if (selections.includes(StylelintOptions.installModule)) {
 
                     const moduleName = 'stylelint @nuxtjs/stylelint-module stylelint-config-recommended-vue'
-                    const command = await getInstallationCommand(moduleName, true)
+                    const command = await getInstallationCommand(moduleName)
 
                     await runCommand({
                         command,

--- a/src/commands/Templates.ts
+++ b/src/commands/Templates.ts
@@ -24,7 +24,7 @@ export const configurePug = (options: string[] = defaultOptions) => {
                 if (selections !== undefined && selections.length > 0) {
                     if (selections.includes(PugConfigurationSteps.installPug)) {
                         const moduleName = 'pug'
-                        const command = await getInstallationCommand(moduleName, true)
+                        const command = await getInstallationCommand(moduleName)
 
                         await runCommand({
                             command,
@@ -36,7 +36,7 @@ export const configurePug = (options: string[] = defaultOptions) => {
 
                     if (selections.includes(PugConfigurationSteps.installLanguagePlugin)) {
                         const moduleName = '@vue/language-plugin-pug'
-                        const command = await getInstallationCommand(moduleName, true)
+                        const command = await getInstallationCommand(moduleName)
 
                         await runCommand({
                             command,

--- a/src/sideBar/index.ts
+++ b/src/sideBar/index.ts
@@ -224,8 +224,7 @@ export class ModulesView implements vscode.WebviewViewProvider {
 
     private async installModule(module: any) {
         const command = await getInstallationCommand(
-            module.npm,
-            module['dependency-type'] === 'dev' ? true : false
+            module.npm
         )
         await vscode.window.withProgress(
             {

--- a/src/utils/dependency.ts
+++ b/src/utils/dependency.ts
@@ -153,16 +153,16 @@ export const detectPackageManagerByName = () => {
     return undefined
 }
 
-export const getInstallationCommand = async (packageName: string, devFlag: boolean) => {
+export const getInstallationCommand = async (packageName: string) => {
     const packageManager = detectPackageManagerByName()
 
     const defaultPackageManager = nuxtrConfiguration().defaultPackageManager
 
     const installationCommand: any = {
-        Yarn: `yarn add ${packageName} ${devFlag ? '-D' : ''}`,
-        NPM: `npm install ${packageName} ${devFlag ? '-D' : ''}`,
-        pnpm: `pnpm add ${packageName} ${devFlag ? '-D' : ''}`,
-        Bun: `bun install ${packageName} ${devFlag ? '-D' : ''}`,
+        Yarn: `yarn add ${packageName} -D`,
+        NPM: `npm install ${packageName} -D`,
+        pnpm: `pnpm add ${packageName} -D`,
+        Bun: `bun install ${packageName} -D`,
     }
 
     if (packageManager) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

Issue: #130 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request is intended to fix issue #130 by refactoring the `getInstallationCommand` function by removing the `devFlag` since every module that is compatible with Nuxt 3 should be installed as a dev dependency rather than a regular dependency. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
