### PR TITLE
docs: typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ### Project Creation
 
-Using `Nuxtr: Create Nuxt project` command, you can create a new Nuxt project with a few steps. You can choose a project starter from [Nuxt Startes](https://nuxt.new) or you can add your own project started:
+Using `Nuxtr: Create Nuxt project` command, you can create a new Nuxt project with a few steps. You can choose a project starter from [Nuxt Starters](https://nuxt.new) or you can add your own project started:
 
 ```JSON
 "nuxtr.projectTemplates": [

--- a/src/sideBar/src/utilities/vscode.ts
+++ b/src/sideBar/src/utilities/vscode.ts
@@ -26,7 +26,7 @@ class VSCodeAPIWrapper {
      * @remarks When running webview code inside a web browser, postMessage will instead
      * log the given message to the console.
      *
-     * @param message Abitrary data (must be JSON serializable) to send to the extension context.
+     * @param message Arbitrary data (must be JSON serializable) to send to the extension context.
      */
     public postMessage(message: unknown) {
         if (this.vsCodeApi) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

<!-- Please ensure there is an open issue and mention its number as #123 -->

I didn't make an issue for the typo change - let me know if you need it?

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Saw a typo in the main description of the  VSCode extension. I wasn't sure if "Startes" was a real word or a typo (so I looked it up and then submitted this PR). 

I found one other typo in the JSDocs.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
