### PR TITLE
fix: generate template as script setup lang="ts"

### DIFF
--- a/src/templates/vueFiles.ts
+++ b/src/templates/vueFiles.ts
@@ -16,7 +16,7 @@ function generateStyleTag(lang: string, scoped: boolean) {
 }
 
 function generateScriptTag(scriptType: string, lang: string) {
-    return `<script${lang === 'ts' ? ' lang="ts"' : ''}${scriptType === 'setup' ? ' setup' : ''}>
+    return `<script${scriptType === 'setup' ? ' setup' : ''}${lang === 'ts' ? ' lang="ts"' : ''}>
 
 </script>`
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

<!-- Please ensure there is an open issue and mention its number as #123 -->
No open issue/discussion. Feel free to close if you're unhappy with the PR.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Currently, Vue files generated by the default Nuxtr settings/template (with the defaults of `script setup` and `typescript` end up as `<script lang="ts" setup>`

For me, logically I think `script setup` is the name, and TypeScript is just language being used, so I've changed the template's order to:
```vue
<script setup lang="ts">

</script>
```

This style suggestion is backed up by Vue's documentation. See naming and code examples here. https://vuejs.org/api/sfc-script-setup

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
