### PR TITLE
feat: normalize component file extension before creating file

### DIFF
--- a/src/commands/Component.ts
+++ b/src/commands/Component.ts
@@ -1,5 +1,5 @@
 import { window } from 'vscode'
-import { createDir, createFile, createSubFolders, generateVueFileBasicTemplate, projectSrcDirectory, showSubFolderQuickPick, } from '../utils';
+import { createDir, createFile, createSubFolders, generateVueFileBasicTemplate, normalizeFileExtension, projectSrcDirectory, showSubFolderQuickPick, } from '../utils';
 
 const createComponent = () => {
     window
@@ -34,7 +34,7 @@ const directCreateComponent = (path: string) => {
         .then((name) => {
             if (!name) { return }
 
-            const filePath = `${path}/${name}.vue`
+            const filePath = `${path}/${normalizeFileExtension(name, '.vue')}.vue`
 
             createFile({
                 fileName: `${name}.vue`,


### PR DESCRIPTION
### 🔗 Linked issue / Discussion

This change removes the duplicated `.vue` extension when creating a component and using a name with an extension.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When creating a new component named `MyComponent.vue`, Nuxtr would create a file named `MyComponent.vue.vue`. This PR normalizes the file name before creating the component, removing the duplicate extension.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
