### PR TITLE
fix: recover `vueBase`, not following file configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ While using the CLI directly from your terminal is perfectly viable, Nuxtr's int
 
 **Nuxt Snippets**: Enhance your development speed with Nuxt snippets. Simply type `nuxt` for components, `use` for Composables, or begin typing Nuxt utilities and select your desired snippet from the list.
 
-Starting 0.2.10, you can inject a dynamic snippet based on your Nuxtr Vue files configuration with `vueBase` or `vueBaseLayout`.
+Starting 0.2.10, you can inject a dynamic snippet based on your Nuxtr Vue files configuration with `vueBase` or `nuxtBaseLayout`.
 
 Nuxt Snippets are enabled by default. You can toggle them on or off using this setting:
 

--- a/src/snippets/index.ts
+++ b/src/snippets/index.ts
@@ -1,8 +1,8 @@
-import { CompletionItem, CompletionItemKind, MarkdownString, extensions, languages } from 'vscode';
-import { resolve } from 'pathe';
-import { readPackageJSON, writePackageJSON } from 'pkg-types'
 import { homedir } from 'node:os';
-import { generateVueFileBasicTemplate } from '../utils';
+import { resolve } from 'pathe';
+import { readPackageJSON, writePackageJSON } from 'pkg-types';
+import { CompletionItem, CompletionItemKind, MarkdownString, extensions, languages } from 'vscode';
+import { generateVueFileTemplate } from '../utils';
 
 interface Snippet {
     language: string;
@@ -17,7 +17,9 @@ export async function toggleSnippets(source: 'Nuxt' | 'Nitro', moveToDisabled: b
 
     const extensionDir = resolve(homeDir, '.vscode', 'extensions', `${extensionName}-${nuxtrVersion}`);
     const pkgJsonPath = resolve(extensionDir, 'package.json');
+
     const pkgJSON = await readPackageJSON(extensionDir);
+
     let snippets: Snippet[] = pkgJSON?.contributes?.snippets || [];
     let disabledSnippets: Snippet[] = pkgJSON?.contributes?.disabled_snippets || [];
 
@@ -48,15 +50,37 @@ languages.registerCompletionItemProvider(
     { language: 'vue' },
     {
         provideCompletionItems() {
-            const completionItem = new CompletionItem('vueBaseLayout', CompletionItemKind.Snippet);
+            const completionItem = new CompletionItem('nuxtBaseLayout', CompletionItemKind.Snippet);
+            completionItem.detail = 'Generate a Nuxt Layout template';
+
+            const template = generateVueFileTemplate('layout');
+
+            const documentation = new MarkdownString();
+            documentation.appendMarkdown(`Generate a Nuxt layout template according to your Nuxtr configuration.\n\n`);
+            documentation.appendCodeblock(template, 'vue');
+
+            completionItem.documentation = documentation;
+            completionItem.kind = CompletionItemKind.Snippet;
+            completionItem.insertText = template;
+
+            return [completionItem];
+        }
+    }
+);
+
+
+languages.registerCompletionItemProvider(
+    { language: 'vue' },
+    {
+        provideCompletionItems() {
+            const completionItem = new CompletionItem('vueBase', CompletionItemKind.Snippet);
             completionItem.detail = 'Generate a Vue file template';
 
-            const template = generateVueFileBasicTemplate('layout');
+            const template = generateVueFileTemplate('page');
 
-            // Create a MarkdownString for documentation with code highlighting
             const documentation = new MarkdownString();
             documentation.appendMarkdown(`Generate a Vue file template according to your Nuxtr configuration.\n\n`);
-            documentation.appendCodeblock(template, 'vue'); // Specify 'vue' as the language for code block highlighting
+            documentation.appendCodeblock(template, 'vue');
 
             completionItem.documentation = documentation;
             completionItem.kind = CompletionItemKind.Snippet;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

Resolves #156
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Recovering `vueBase` snippet and renaming `vueBaseLayout` to `nuxtBaseLayout`. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
