### PR TITLE
fix: neglect `use` prefix in composables name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1109,7 +1109,7 @@
     "changelogen": "^0.5.7",
     "eslint": "^9.11.0",
     "eslint-config-unjs": "^0.3.2",
-    "knip": "^5.30.2",
+    "knip": "^5.30.4",
     "nuxi-nightly": "^3.14.0-20240921-193235-ef57bb1",
     "taze": "^0.16.9",
     "terser": "^5.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2(eslint@9.11.0(jiti@2.0.0-rc.1))(typescript@5.6.2)
       knip:
-        specifier: ^5.30.2
-        version: 5.30.2(@types/node@20.16.5)(typescript@5.6.2)
+        specifier: ^5.30.4
+        version: 5.30.4(@types/node@20.16.5)(typescript@5.6.2)
       nuxi-nightly:
         specifier: ^3.14.0-20240921-193235-ef57bb1
         version: 3.14.0-20240921-193235-ef57bb1
@@ -1592,8 +1592,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  knip@5.30.2:
-    resolution: {integrity: sha512-UuUwuTN+6Aa6mjxufWwidayGX/tPJsxZSlwUo8q4R+Gf/0aNYuhHsUH/GccuKtRPfFnf3r+ZU/7BV0dNfC7OEQ==}
+  knip@5.30.4:
+    resolution: {integrity: sha512-ws9HtVEMyEFFlGZ3+XCC/XQ0dRfllaW0TVWQJzYTJprAvB98cy3mSH4wZo1UkzdPe6l+qbJJxnGuG69Jm916BQ==}
     engines: {node: '>=18.6.0'}
     hasBin: true
     peerDependencies:
@@ -3979,7 +3979,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.30.2(@types/node@20.16.5)(typescript@5.6.2):
+  knip@5.30.4(@types/node@20.16.5)(typescript@5.6.2):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@snyk/github-codeowners': 1.1.0

--- a/src/commands/composable.ts
+++ b/src/commands/composable.ts
@@ -2,6 +2,8 @@ import { window } from 'vscode'
 import { composableTemplate } from '../templates'
 import { createDir, createFile, createSubFolders, normalizeFileExtension, projectSrcDirectory, showSubFolderQuickPick } from '../utils'
 
+const neglectUsePrefix = (name: string) => name.replace(/^use/i, '')
+
 const createComposable = () => {
     window
         .showInputBox({
@@ -22,7 +24,7 @@ const createComposable = () => {
                 name,
                 subFolders,
                 commandType: 'composables',
-                content: composableTemplate(name),
+                content: composableTemplate(neglectUsePrefix(name)),
             })
 
         })
@@ -41,7 +43,7 @@ const directCreateComposable = (path: string) => {
 
             createFile({
                 fileName: `${name}.ts`,
-                content: composableTemplate(name),
+                content: composableTemplate(neglectUsePrefix(name)),
                 fullPath: filePath,
             })
         })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Some users add `use` in composables name resulting to duplicating the word. This PR fixes it. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
