### PR TITLE
Change URL to official Tabler Icons website

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Nuxtr relies on the following projects/repositories:
 
 - [Nuxt Modules](https://github.com/nuxt/modules)
 - [Nuxt Assets](https://github.com/nuxt/assets)
-- [Tabler Icons](https://tablericons.com/)
+- [Tabler Icons](https://tabler.io/icons)
 
 <br>
 


### PR DESCRIPTION
Hi!

I wanted to kindly ask if you could update the link to Tabler Icons to the correct URL: https://tabler.io/icons.

The current site, tablericons. com, isn’t affiliated with the Tabler Icons project. The person behind it is misleading users by claiming to be the author of the library. You can verify the official project and its details here: https://github.com/tabler/tabler-icons.

Thanks so much for your understanding and for supporting accurate representation of the Tabler project!

Best regards
Bartek, co-owner of Tabler