### PR TITLE
feat: add support for pnpm catalogs

### DIFF
--- a/src/utils/nuxt.ts
+++ b/src/utils/nuxt.ts
@@ -111,7 +111,18 @@ export const getNuxtVersion = (): string | undefined => {
         };
         if ('nuxt' in dependencies) {
             const nuxtVersion = dependencies.nuxt;
-            return nuxtVersion.replace('^', '');
+
+            if (!nuxtVersion.includes('catalog:')) {
+                return nuxtVersion.replace('^', '');
+            }
+
+            const workspaceConfigPath = `${projectRootDirectory()}/pnpm-workspace.yaml`;
+            const workspaceConfig = readFileSync(workspaceConfigPath, 'utf8')
+
+            const regex = /[\s]['"]?nuxt['"]?[\s]*:[^0-9\n\r]*(?<version>[0-9]+(?:\.[0-9]+){0,2})/g
+            const matches = regex.exec(workspaceConfig)
+
+            return matches?.groups?.version
         }
     } else {
         return;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/nuxtrdev/nuxtr-vscode/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue / Discussion

<!-- Please ensure there is an open issue and mention its number as #123 -->

No issue opened. Change was small enough to PR directly.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, Nuxtr errors when using [pnpm catalogs](https://pnpm.io/catalogs) to manage `nuxt`'s version.

This PR introduces a way for this extension to get the version number from `pnpm-workspace.yaml` using a regex to avoid adding any extra dependencies to the project. 

This regex is extremely naive and doesn't check for the specific catalog where  `nuxt` is supposed to be defined. Despite this it supports configs using simple, double or no quotes for the dependency name and version number (mix and match too). It also allows you to use anchors and aliases as long as a version number is specified in the `nuxt` line.

This is what my current config looks like and what I tested these changes with:

```yaml
catalogs:
  nuxt:
    "nuxt": &nuxt "3.16.2"
    "@nuxt/kit": *nuxt
    "@nuxt/schema": *nuxt
```

Might be a good idea to add tests to ensure the regex works as expected in the future but since they're not set up in the project, we might tackle this in a separate PR if you want.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Not sure if this is something we would need to document since it is a change to an internal function.
